### PR TITLE
forceOpen/forceClosed generalConfig fields don't work as expected

### DIFF
--- a/v3/config.go
+++ b/v3/config.go
@@ -139,6 +139,14 @@ func (g *GeneralConfig) merge(other GeneralConfig) {
 	}
 	g.mergeCustomConfig(other)
 
+	if !g.ForceOpen {
+		g.ForceOpen = other.ForceOpen
+	}
+
+	if !g.ForcedClosed {
+		g.ForcedClosed = other.ForcedClosed
+	}
+
 	if g.GoLostErrors == nil {
 		g.GoLostErrors = other.GoLostErrors
 	}

--- a/v3/config_test.go
+++ b/v3/config_test.go
@@ -1,0 +1,43 @@
+package circuit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneralConfig_Merge(t *testing.T) {
+
+	t.Run("respect ForceOpen field of args cfg", func(t *testing.T) {
+		cfg := GeneralConfig{}
+
+		cfg.merge(GeneralConfig{ForceOpen: true})
+
+		assert.True(t, cfg.ForceOpen, "expect to be true")
+	})
+
+	t.Run("respect ForceOpen field of receiver cfg", func(t *testing.T) {
+		cfg := GeneralConfig{ForceOpen: true}
+
+		cfg.merge(GeneralConfig{ForceOpen: false})
+
+		assert.True(t, cfg.ForceOpen, "expect to be true")
+	})
+
+	t.Run("respect ForceClosed field of args cfg", func(t *testing.T) {
+		cfg := GeneralConfig{}
+
+		cfg.merge(GeneralConfig{ForcedClosed: true})
+
+		assert.True(t, cfg.ForcedClosed, "expect to be true")
+	})
+
+	t.Run("respect ForceClosed field of receiver cfg", func(t *testing.T) {
+		cfg := GeneralConfig{ForcedClosed: true}
+
+		cfg.merge(GeneralConfig{ForceOpen: false})
+
+		assert.True(t, cfg.ForcedClosed, "expect to be true")
+	})
+
+}


### PR DESCRIPTION
```go
	mustFailCircuit := h.MustCreateCircuit(host, circuit.Config{
		General: circuit.GeneralConfig{
			ForceOpen: true,
		},
	})
       
        err := shouldFailCircuit.Execute(
			context.Background(),
			func(_ context.Context) error { return nil },
			nil,
		)
       fmt.Println(err) // I expect to err equal to errCircuitOpen but nil found
       
       // output: nil
```