### PR TITLE
Treat deadline expired as failure

### DIFF
--- a/v3/circuit.go
+++ b/v3/circuit.go
@@ -2,6 +2,7 @@ package circuit
 
 import (
 	"context"
+	"errors"
 	"expvar"
 	"sync"
 	"time"
@@ -335,7 +336,7 @@ func (c *Circuit) checkSuccess(runFuncDoneTime time.Time, totalCmdTime time.Dura
 }
 
 func (c *Circuit) checkErrInterrupt(originalContext context.Context, ret error, runFuncDoneTime time.Time, totalCmdTime time.Duration) bool {
-	if !c.threadSafeConfig.GoSpecific.IgnoreInterrupts.Get() && ret != nil && originalContext.Err() != nil {
+	if !c.threadSafeConfig.GoSpecific.IgnoreInterrupts.Get() && ret != nil && errors.Is(originalContext.Err(), context.Canceled) {
 		c.CmdMetricCollector.ErrInterrupt(runFuncDoneTime, totalCmdTime)
 		return true
 	}

--- a/v3/circuit_test.go
+++ b/v3/circuit_test.go
@@ -570,19 +570,14 @@ func openOnFirstErrorFactory() ClosedToOpen {
 
 type closeOnFirstErrorOpener struct {
 	ClosedToOpen
-	isOpenedMutex sync.RWMutex
-	isOpened      bool
+	isOpened bool
 }
 
 func (o *closeOnFirstErrorOpener) ShouldOpen(_ time.Time) bool {
-	o.isOpenedMutex.Lock()
-	defer o.isOpenedMutex.Unlock()
 	o.isOpened = true
 	return true
 }
 func (o *closeOnFirstErrorOpener) Prevent(_ time.Time) bool {
-	o.isOpenedMutex.RLock()
-	defer o.isOpenedMutex.RUnlock()
 	return o.isOpened
 }
 

--- a/v3/config.go
+++ b/v3/config.go
@@ -47,8 +47,6 @@ type ExecutionConfig struct {
 	MaxConcurrentRequests int64
 	// Normally if the parent context is canceled before a timeout is reached, we don't consider the circuit
 	// unhealth.  Set this to true to consider those circuits unhealthy.
-	// Note: This is a typo: Should be renamed as IgnoreInterrupts.  Tracking this in
-	//       https://github.com/cep21/circuit/issues/39
 	IgnoreInterrupts bool `json:",omitempty"`
 }
 

--- a/v3/config_test.go
+++ b/v3/config_test.go
@@ -41,3 +41,28 @@ func TestGeneralConfig_Merge(t *testing.T) {
 	})
 
 }
+
+func TestExecutionConfig_Merge(t *testing.T) {
+
+	t.Run("isErrInterrupt check function", func(t *testing.T) {
+		cfg := ExecutionConfig{}
+
+		cfg.merge(ExecutionConfig{IsErrInterrupt: func(e error) bool { return e != nil }})
+
+		assert.NotNil(t, cfg.IsErrInterrupt)
+	})
+
+	t.Run("ignore isErrInterrupt if previously set", func(t *testing.T) {
+		fn1 := func(err error) bool { return true }
+		fn2 := func(err error) bool { return false }
+
+		cfg := ExecutionConfig{
+			IsErrInterrupt: fn1,
+		}
+
+		cfg.merge(ExecutionConfig{IsErrInterrupt: fn2})
+
+		assert.NotNil(t, fn1, cfg.IsErrInterrupt)
+		assert.True(t, cfg.IsErrInterrupt(nil))
+	})
+}


### PR DESCRIPTION
if the parent context is canceled before a timeout is reached, we don't consider the circuit unhealthy. But `originalContext.Err()` can be also `context.DeadlineExceeded`.
Should we treat `context.DeadlineExceeded` as failures ?