### PR TITLE
ErrBadRequest should be considered as successful attempts

### DIFF
--- a/v3/circuit.go
+++ b/v3/circuit.go
@@ -300,6 +300,7 @@ func (c *Circuit) run(ctx context.Context, runFunc func(context.Context) error) 
 	// The HystrixBadRequestException is intended for use cases such as reporting illegal arguments or non-system
 	// failures that should not count against the failure metrics and should not trigger fallback logic.
 	if c.checkErrBadRequest(ret, runFuncDoneTime, totalCmdTime) {
+		c.close(runFuncDoneTime, false) // Attempt to close the circuit
 		return ret
 	}
 
@@ -329,9 +330,7 @@ func (c *Circuit) run(ctx context.Context, runFunc func(context.Context) error) 
 
 func (c *Circuit) checkSuccess(runFuncDoneTime time.Time, totalCmdTime time.Duration) {
 	c.CmdMetricCollector.Success(runFuncDoneTime, totalCmdTime)
-	if c.IsOpen() {
-		c.close(runFuncDoneTime, false)
-	}
+	c.close(runFuncDoneTime, false)
 }
 
 // checkErrInterrupt returns true if this is considered an interrupt error: interrupt errors do not open the circuit.

--- a/v3/closers/hystrix/closer.go
+++ b/v3/closers/hystrix/closer.go
@@ -98,8 +98,9 @@ func (s *Closer) Success(now time.Time, duration time.Duration) {
 	s.concurrentSuccessfulAttempts.Add(1)
 }
 
-// ErrBadRequest is ignored
+// ErrBadRequest is considered as healthy, so we count it as success here
 func (s *Closer) ErrBadRequest(now time.Time, duration time.Duration) {
+	s.concurrentSuccessfulAttempts.Add(1)
 }
 
 // ErrInterrupt is ignored


### PR DESCRIPTION
From [README.md](https://github.com/cep21/circuit#not-counting-user-error-as-a-fault), it is stated that `SimpleBadRequest` does not count as a failure and will not cause the circuit to open.

By that, I think when the circuit is already in the open state, `SimpleBadRequest` should be considered as a **healthy** result and is counted to the number of successful attempts, which could trigger the circuit to recover/close.

Currently, `circuit.go` is not doing that. Check the [failing test](https://github.com/cep21/circuit/pull/99/commits/3859e67267401b648333e7b14d8bc3ff59617ea9): 

```go
func TestCircuitAttemptClosesWithBadRequest(t *testing.T) {
	c := NewCircuitFromConfig("TestCircuitAttemptClosesWithBadRequest", Config{
		General: GeneralConfig{
			OpenToClosedFactory: alwaysClosesFactory,
		},
	})
	c.OpenCircuit()
	c.Run(context.Background(), func(_ context.Context) error {
		return SimpleBadRequest{
			errors.New("this request is bad"),
		}
	})
	if c.IsOpen() {
		t.Errorf("I should be closed now")
	}
```

In this PR, I modified the `run` method to attempt to close the circuit in case of `ErrBadRequest`. I also updated the `hystrix/closer.go` to count `ErrBadRequest` and `ErrInterrupt` as success attempts.
