### PR TITLE
Disabled field's value for General config lost in merge method

### DIFF
--- a/v3/config.go
+++ b/v3/config.go
@@ -146,6 +146,10 @@ func (g *GeneralConfig) merge(other GeneralConfig) {
 	}
 	g.mergeCustomConfig(other)
 
+	if !g.Disabled {
+		g.Disabled = other.Disabled
+	}
+
 	if !g.ForceOpen {
 		g.ForceOpen = other.ForceOpen
 	}

--- a/v3/config_test.go
+++ b/v3/config_test.go
@@ -8,6 +8,22 @@ import (
 
 func TestGeneralConfig_Merge(t *testing.T) {
 
+	t.Run("respect Disabled field of args cfg", func(t *testing.T) {
+		cfg := GeneralConfig{}
+
+		cfg.merge(GeneralConfig{Disabled: true})
+
+		assert.True(t, cfg.Disabled, "expect to be true")
+	})
+
+	t.Run("respect Disabled field of receiver cfg", func(t *testing.T) {
+		cfg := GeneralConfig{Disabled: true}
+
+		cfg.merge(GeneralConfig{Disabled: false})
+
+		assert.True(t, cfg.Disabled, "expect to be true")
+	})
+
 	t.Run("respect ForceOpen field of args cfg", func(t *testing.T) {
 		cfg := GeneralConfig{}
 


### PR DESCRIPTION
Disabled field's value for General config lost in merge method
```go
cfg := GeneralConfig{}
cfg.merge(GeneralConfig{Disabled: true})
if !cfg.Disabled {  
   panic("expect Disabled equal to true")
}
```
this is very similar to https://github.com/cep21/circuit/pull/93 but for `Disabled` field