### PR TITLE
Fix typo in errThrottledConcurrentCommands

### DIFF
--- a/v3/circuit.go
+++ b/v3/circuit.go
@@ -243,7 +243,7 @@ func (c *Circuit) Execute(ctx context.Context, runFunc func(context.Context) err
 
 func (c *Circuit) throttleConcurrentCommands(currentCommandCount int64) error {
 	if c.threadSafeConfig.Execution.MaxConcurrentRequests.Get() >= 0 && currentCommandCount > c.threadSafeConfig.Execution.MaxConcurrentRequests.Get() {
-		return errThrottledConcucrrentCommands
+		return errThrottledConcurrentCommands
 	}
 	return nil
 }

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -2,7 +2,7 @@ package circuit
 
 import "fmt"
 
-var errThrottledConcucrrentCommands = &circuitError{concurrencyLimitReached: true, msg: "throttling connections to command"}
+var errThrottledConcurrentCommands = &circuitError{concurrencyLimitReached: true, msg: "throttling connections to command"}
 var errCircuitOpen = &circuitError{circuitOpen: true, msg: "circuit is open"}
 
 // circuitError is used for internally generated errors


### PR DESCRIPTION
This PR fixes the typo in `errThrottledConcurrentCommands`.